### PR TITLE
TTT-21 (bug) [SonarQube] format string is not a string literal (potentially insecure)

### DIFF
--- a/c/keylogger.c
+++ b/c/keylogger.c
@@ -7,10 +7,10 @@ int keylog()
     FILE * fPtr;
     fPtr = fopen("keylogger.txt", "w+");
 
-    const char *a = getchar();
+    char a = getchar();
     
-    if(a != NULL)
-        fprintf(fPtr, "%c", *a);
+    if(a != '\0')
+        fprintf(fPtr, "%c", a);
     
     time_t now = time(NULL);
     struct tm *tm_struct = localtime(&now);


### PR DESCRIPTION
TTT-21 (bug) [SonarQube] format string is not a string literal (potentially insecure)