### PR TITLE
TTT-23 (bug) [SonarQube] Make the type of this variable a pointer-to-const. The current type of "tm_struct" is "struct tm *".

### DIFF
--- a/c/keylogger.c
+++ b/c/keylogger.c
@@ -13,7 +13,7 @@ int keylog()
         fprintf(fPtr, "%c", a);
     
     time_t now = time(NULL);
-    struct tm *tm_struct = localtime(&now);
+    const struct tm *tm_struct = localtime(&now);
     int hour = tm_struct->tm_hour;
     
     if(hour == 24)


### PR DESCRIPTION
TTT-23 (bug) [SonarQube] Make the type of this variable a pointer-to-const. The current type of "tm_struct" is "struct tm *".