### PR TITLE
TTT-24 (bug) [SonarQube] Replace this call to the non reentrant function "localtime" by a call to "localtime_r".

### DIFF
--- a/c/keylogger.c
+++ b/c/keylogger.c
@@ -13,8 +13,9 @@ int keylog()
         fprintf(fPtr, "%c", a);
     
     time_t now = time(NULL);
-    const struct tm *tm_struct = localtime(&now);
-    int hour = tm_struct->tm_hour;
+    struct tm tm_struct;
+    localtime_r(&now, &tm_struct);
+    int hour = tm_struct.tm_hour;
     
     if(hour == 24)
         fclose(fPtr);


### PR DESCRIPTION
TTT-24 (bug) [SonarQube] Replace this call to the non reentrant function "localtime" by a call to "localtime_r".