### PR TITLE
HDS-2 (bug) [SonarQube] Access of 'yarr' at index 2, while it holds only 2 'const char *' elements

### DIFF
--- a/c/linearsearch.c
+++ b/c/linearsearch.c
@@ -4,7 +4,7 @@
 
 int linsearch(const char **yarr, const char *val)
 {
-    for(int i = 0; i < sizeof(yarr); i++)
+    for(int i = 0; i < sizeof(yarr) / sizeof(yarr[0]); i++)
     {
         if(strcmp(yarr[i], val) == 0)
         {


### PR DESCRIPTION
HDS-2 (bug) [SonarQube] Access of 'yarr' at index 2, while it holds only 2 'const char *' elements